### PR TITLE
Add ability to use macros as function calls; add type definitions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/node_modules

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,13 @@
+import { IconName, IconProp } from '@fortawesome/fontawesome-svg-core'
+
+export function far(t: TemplateStringsArray): IconProp
+export function fas(t: TemplateStringsArray): IconProp
+export function fal(t: TemplateStringsArray): IconProp
+export function fab(t: TemplateStringsArray): IconProp
+export function fad(t: TemplateStringsArray): IconProp
+
+export function far(iconName: IconName): IconProp
+export function fas(iconName: IconName): IconProp
+export function fal(iconName: IconName): IconProp
+export function fab(iconName: IconName): IconProp
+export function fad(iconName: IconName): IconProp

--- a/package.json
+++ b/package.json
@@ -6,5 +6,11 @@
   "dependencies": {
     "@babel/helper-module-imports": "^7.8.3",
     "babel-plugin-macros": "^2.8.0"
+  },
+  "prettier": {
+    "singleQuote": true,
+    "semi": false,
+    "trailingComma": "none",
+    "arrowParens": "avoid"
   }
 }


### PR DESCRIPTION
Compared to template literals, function calls are more type-safe in TypeScript.