### PR TITLE
Source Code Refactored

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,14 +12,13 @@ function capitalize(str) {
 
 function camelCase(str) {
   return str
+    .toLowerCase()
     .split('-')
-    .map((s, index) => {
-      return (
-        (index === 0 ? s[0].toLowerCase() : s[0].toUpperCase()) +
-        s.slice(1).toLowerCase()
-      )
-    })
-    .join('')
+    .map(
+      (s, index) =>
+        (index === 0 ? s[0].toLowerCase() : s[0].toUpperCase()) + s.slice(1)
+    )
+    .join('');
 }
 
 function replaceWithImportedIcon(


### PR DESCRIPTION
The string will be converted to lowercase before performing string operations which are better than performing the lowercase operation in the middle and the return keyword is being removed from the arrow function since it wasn't required after code refactoring plus it also obstructed readability due to multiple chaining